### PR TITLE
fix: hide vertical navbar and close-button on md breakpoint

### DIFF
--- a/src/pages/templates/navigation/navbar/simple.tsx
+++ b/src/pages/templates/navigation/navbar/simple.tsx
@@ -45,7 +45,7 @@ export default function Simple() {
             size={'md'}
             icon={isOpen ? <CloseIcon /> : <HamburgerIcon />}
             aria-label={'Open Menu'}
-            display={{ md: !isOpen ? 'none' : 'inherit' }}
+            display={{ md: 'none' }}
             onClick={isOpen ? onClose : onOpen}
           />
           <HStack spacing={8} alignItems={'center'}>
@@ -84,7 +84,7 @@ export default function Simple() {
         </Flex>
 
         {isOpen ? (
-          <Box pb={4}>
+          <Box pb={4} display={{ md: 'none' }}>
             <Stack as={'nav'} spacing={4}>
               {Links.map((link) => (
                 <NavLink key={link}>{link}</NavLink>

--- a/src/pages/templates/navigation/navbar/withAction.tsx
+++ b/src/pages/templates/navigation/navbar/withAction.tsx
@@ -45,7 +45,7 @@ export default function withAction() {
             size={'md'}
             icon={isOpen ? <CloseIcon /> : <HamburgerIcon />}
             aria-label={'Open Menu'}
-            display={{ md: !isOpen ? 'none' : 'inherit' }}
+            display={{ md: 'none' }}
             onClick={isOpen ? onClose : onOpen}
           />
           <HStack spacing={8} alignItems={'center'}>
@@ -92,7 +92,7 @@ export default function withAction() {
         </Flex>
 
         {isOpen ? (
-          <Box pb={4}>
+          <Box pb={4} display={{ md: 'none' }}>
             <Stack as={'nav'} spacing={4}>
               {Links.map((link) => (
                 <NavLink key={link}>{link}</NavLink>


### PR DESCRIPTION
I am not 100% sure if the commit message is valid English. I wanted to avoid the ambiguity of the sentence "hide vertical navbar and close button on md breakpoint"(it can be interpreted as [hide vertical navbar] and [close button] on md breakpoint). If you want I can amend it.

See attached video for demo of what problem this solves.

https://user-images.githubusercontent.com/24797093/118111329-d3f61500-b3e3-11eb-941f-5957a84436f7.mp4

