### PR TITLE
fix: Stretched image

### DIFF
--- a/src/pages/templates/page-sections/features/splitWithImage.tsx
+++ b/src/pages/templates/page-sections/features/splitWithImage.tsx
@@ -96,6 +96,7 @@ export default function SplitWithImage() {
             src={
               'https://images.unsplash.com/photo-1554200876-56c2f25224fa?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1350&q=80'
             }
+            objectFit={'cover'}
           />
         </Flex>
       </SimpleGrid>


### PR DESCRIPTION
Without 'object-fit: cover' the image used in the template '2 columns with Image' appeared stretched and awkward. This PR fixes that.

**Before:**
![2021-07-11 at 00 36 27](https://user-images.githubusercontent.com/458311/125178807-11a6cc80-e1e0-11eb-8c9d-0fa69a2dee71.png)

**After:**
![2021-07-11 at 00 37 22](https://user-images.githubusercontent.com/458311/125178817-30a55e80-e1e0-11eb-84c5-453638b5ddf3.png)
