### PR TITLE
feat: changed logo position

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -56,8 +56,9 @@ export const Header = () => {
         }}>
         <Container as={Flex} maxW={'7xl'} align={'center'}>
           <Flex
-            flex={{ base: 1, md: 'auto' }}
+            flex={{ base: '0', md: 'auto' }}
             ml={{ base: -2 }}
+            mr={{ base: 6, md: 0 }}
             display={{ base: 'flex', md: 'none' }}>
             <IconButton
               onClick={onToggle}
@@ -76,7 +77,7 @@ export const Header = () => {
 
           <Flex
             flex={{ base: 1, md: 'auto' }}
-            justify={{ base: 'center', md: 'start' }}>
+            justify={{ base: 'start', md: 'start' }}>
             <Link href={'/'} passHref>
               <Stack
                 as={'a'}
@@ -97,7 +98,7 @@ export const Header = () => {
           <Stack
             direction={'row'}
             align={'center'}
-            spacing={8}
+            spacing={{ base: 6, md: 8 }}
             flex={{ base: 1, md: 'auto' }}
             justify={'flex-end'}>
             <DesktopNav display={{ base: 'none', md: 'flex' }} />


### PR DESCRIPTION
After the integration of HyperTheme, the Logo in Header is not centered on mobile, so we moved the logo on the left corner.
<img width="377" alt="Schermata 2021-07-23 alle 16 47 19" src="https://user-images.githubusercontent.com/8491676/126799445-67c8187c-9f9c-4a1d-8a55-63663f1b160d.png">
