### PR TITLE
Rename component to Pricing ✏️

### DIFF
--- a/src/pages/templates/components/cards/pricing.tsx
+++ b/src/pages/templates/components/cards/pricing.tsx
@@ -11,7 +11,7 @@ import {
 } from '@chakra-ui/react';
 import { CheckIcon } from '@chakra-ui/icons';
 
-export default function blogPostWithImage() {
+export default function Pricing() {
   return (
     <Center py={6}>
       <Box


### PR DESCRIPTION
Both `Blog Post with Image` and `Pricing` components have same export function name.
for this file it should be "Pricing" or "PricingCard"