### PR TITLE
Fix sidebar navigation item onFocus box-shadow

### DIFF
--- a/src/pages/templates/navigation/sidebar/sidebarWithHeader.tsx
+++ b/src/pages/templates/navigation/sidebar/sidebarWithHeader.tsx
@@ -116,7 +116,7 @@ interface NavItemProps extends FlexProps {
 }
 const NavItem = ({ icon, children, ...rest }: NavItemProps) => {
   return (
-    <Link href="#" style={{ textDecoration: 'none' }}>
+    <Link href="#" style={{ textDecoration: 'none' }} _focus={{ boxShadow: 'none' }}>
       <Flex
         align="center"
         p="4"

--- a/src/pages/templates/navigation/sidebar/simpleSidebar.tsx
+++ b/src/pages/templates/navigation/sidebar/simpleSidebar.tsx
@@ -101,7 +101,7 @@ interface NavItemProps extends FlexProps {
 }
 const NavItem = ({ icon, children, ...rest }: NavItemProps) => {
   return (
-    <Link href="#" style={{ textDecoration: 'none' }}>
+    <Link href="#" style={{ textDecoration: 'none' }} _focus={{ boxShadow: 'none' }}>
       <Flex
         align="center"
         p="4"


### PR DESCRIPTION
Fixes #135 by adding `_focus={{ boxShadow: 'none' }}` to the `<Link/>`