### PR TITLE
General-purpose buttons

### DIFF
--- a/src/data/components/buttons.ts
+++ b/src/data/components/buttons.ts
@@ -1,0 +1,20 @@
+import { SubCategory } from '../types';
+
+export const buttons: SubCategory = {
+  name: 'Buttons',
+  id: 'buttons',
+  children: [
+    {
+      name: 'Color Mode Toggle',
+      filename: 'colorModeToggle',
+    },
+    {
+      name: 'Secondary Options with Menu',
+      filename: 'secondaryOptions',
+    },
+    {
+      name: 'Button with Tabbed Popover',
+      filename: 'buttonTabbedPopover',
+    },
+  ],
+};

--- a/src/data/components/socialMediaButtons.ts
+++ b/src/data/components/socialMediaButtons.ts
@@ -1,6 +1,6 @@
 import { SubCategory } from '../types';
 
-export const buttons: SubCategory = {
+export const socialButtons: SubCategory = {
   name: 'Social Media Buttons',
   id: 'social-media-buttons',
   children: [

--- a/src/data/index.tsx
+++ b/src/data/index.tsx
@@ -1,4 +1,5 @@
-import { buttons } from './components/socialMediaButtons';
+import { socialButtons } from './components/socialMediaButtons';
+import { buttons } from './components/buttons';
 import { cards } from './components/cards';
 import { result } from './components/result';
 import { hero } from './templates/hero';
@@ -31,7 +32,7 @@ export const data: Category[] = [
       pricing,
       statistics,
       carousel,
-      product
+      product,
     ],
   },
   {
@@ -56,6 +57,6 @@ export const data: Category[] = [
     name: 'Components',
     id: 'components',
     subLabel: 'Smaller buildings blocks like Cards, Buttons, Result ...',
-    children: [cards, buttons, result],
+    children: [cards, buttons, socialButtons, result],
   },
 ];

--- a/src/pages/templates/components/buttons/buttonTabbedPopover.tsx
+++ b/src/pages/templates/components/buttons/buttonTabbedPopover.tsx
@@ -1,0 +1,82 @@
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverHeader,
+  PopoverBody,
+  PopoverArrow,
+  PopoverCloseButton,
+  Button,
+  Tabs,
+  TabList,
+  Tab,
+  TabPanels,
+  TabPanel,
+  Flex,
+} from '@chakra-ui/react';
+import { ChevronDownIcon } from '@chakra-ui/icons';
+
+const ServerQuickActions = () => {
+  return (
+    /**
+     * You may move the Popover outside Flex.
+     */
+    <Flex justifyContent="center" mt={4}>
+      <Popover placement="bottom" isLazy>
+        <PopoverTrigger>
+          <Button
+            rightIcon={<ChevronDownIcon />}
+            colorScheme="green"
+            w="fit-content">
+            Quick Actions
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent _focus={{ boxShadown: 'none' }}>
+          <PopoverArrow />
+          <PopoverCloseButton />
+          <PopoverHeader fontWeight="bold">Quick Actions</PopoverHeader>
+          <PopoverBody w="full">
+            <Tabs isLazy colorScheme="green">
+              <TabList>
+                <Tab
+                  _focus={{ boxShadow: 'none' }}
+                  fontSize="xs"
+                  fontWeight="bold"
+                  w="50%">
+                  Access
+                </Tab>
+                <Tab
+                  _focus={{ boxShadow: 'none' }}
+                  fontSize="xs"
+                  fontWeight="bold"
+                  w="50%">
+                  Services
+                </Tab>
+              </TabList>
+              <TabPanels>
+                <TabPanel>
+                  {/* You can add your content here. */}
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                  do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                  Elementum curabitur vitae nunc sed velit dignissim sodales ut
+                  eu. Mauris nunc congue nisi vitae suscipit tellus mauris a
+                  diam. Eros in cursus turpis massa tincidunt.
+                </TabPanel>
+                <TabPanel>
+                  {/* You can add your content here. */}
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                  do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                  Elementum curabitur vitae nunc sed velit dignissim sodales ut
+                  eu. Mauris nunc congue nisi vitae suscipit tellus mauris a
+                  diam. Eros in cursus turpis massa tincidunt.
+                </TabPanel>
+              </TabPanels>
+            </Tabs>
+          </PopoverBody>
+        </PopoverContent>
+      </Popover>
+    </Flex>
+  );
+};
+
+export default ServerQuickActions;

--- a/src/pages/templates/components/buttons/colorModeToggle.tsx
+++ b/src/pages/templates/components/buttons/colorModeToggle.tsx
@@ -1,0 +1,22 @@
+import { Button, ButtonProps, Flex, useColorMode } from '@chakra-ui/react';
+import { BsSun, BsMoonStarsFill } from 'react-icons/bs';
+
+export default function ColorModeToggle(props: ButtonProps) {
+  const { colorMode, toggleColorMode } = useColorMode();
+  return (
+    /**
+     * Ideally, only the button component should be used (without Flex).
+     * Props compatible with <Button /> are supported.
+     */
+    <Flex h="100vh" justifyContent="center" alignItems="center">
+      <Button
+        aria-label="Toggle Color Mode"
+        onClick={toggleColorMode}
+        _focus={{ boxShadow: 'none' }}
+        w="fit-content"
+        {...props}>
+        {colorMode === 'light' ? <BsMoonStarsFill /> : <BsSun />}
+      </Button>
+    </Flex>
+  );
+}

--- a/src/pages/templates/components/buttons/secondaryOptions.tsx
+++ b/src/pages/templates/components/buttons/secondaryOptions.tsx
@@ -1,0 +1,80 @@
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverBody,
+  PopoverArrow,
+  IconButton,
+  Button,
+  Stack,
+  Flex,
+} from '@chakra-ui/react';
+
+import { BsThreeDotsVertical, BsChatSquareQuote } from 'react-icons/bs';
+import { RiShutDownLine, RiRestartLine, RiFileShredLine } from 'react-icons/ri';
+
+export default function ServerSecondaryOptions() {
+  return (
+    /**
+     * You may move the Popover outside Flex.
+     */
+    <Flex justifyContent="center" mt={4}>
+      <Popover placement="bottom" isLazy>
+        <PopoverTrigger>
+          <IconButton
+            aria-label="More server options"
+            icon={<BsThreeDotsVertical />}
+            variant="solid"
+            w="fit-content"
+          />
+        </PopoverTrigger>
+        <PopoverContent w="fit-content" _focus={{ boxShadow: 'none' }}>
+          <PopoverArrow />
+          <PopoverBody>
+            <Stack>
+              <Button
+                w="194px"
+                variant="ghost"
+                rightIcon={<BsChatSquareQuote />}
+                justifyContent="space-between"
+                fontWeight="normal"
+                fontSize="sm">
+                Request Access
+              </Button>
+              <Button
+                w="194px"
+                variant="ghost"
+                rightIcon={<RiFileShredLine />}
+                justifyContent="space-between"
+                fontWeight="normal"
+                colorScheme="red"
+                fontSize="sm">
+                Purge Redis Cache
+              </Button>
+              <Button
+                w="194px"
+                variant="ghost"
+                rightIcon={<RiRestartLine />}
+                justifyContent="space-between"
+                fontWeight="normal"
+                colorScheme="red"
+                fontSize="sm">
+                Restart Server
+              </Button>
+              <Button
+                w="194px"
+                variant="ghost"
+                rightIcon={<RiShutDownLine />}
+                justifyContent="space-between"
+                fontWeight="normal"
+                colorScheme="red"
+                fontSize="sm">
+                Disable Server
+              </Button>
+            </Stack>
+          </PopoverBody>
+        </PopoverContent>
+      </Popover>
+    </Flex>
+  );
+}


### PR DESCRIPTION
Currently, Chakra Templates has no general purpose buttons. Buttons need to be extracted from other templates and components.

This PR contains code towards three (3) general purpose buttons -
1. Color Mode Toggle
2. Secondary Options Menu
3. Button with Tabbed Popover

I have also renamed Social Button subcategory from `buttons` to `socialButtons` and made some linting fixes.