### PR TITLE
FTR: Used Chakra Image instead of Next, and removed fixed height so t…

### DIFF
--- a/src/pages/templates/components/cards/blogPostWithImage.tsx
+++ b/src/pages/templates/components/cards/blogPostWithImage.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image';
 import {
   Box,
   Center,
@@ -7,6 +6,7 @@ import {
   Stack,
   Avatar,
   useColorModeValue,
+  Image,
 } from '@chakra-ui/react';
 
 export default function blogPostWithImage() {
@@ -20,18 +20,11 @@ export default function blogPostWithImage() {
         rounded={'md'}
         p={6}
         overflow={'hidden'}>
-        <Box
-          h={'210px'}
-          bg={'gray.100'}
-          mt={-6}
-          mx={-6}
-          mb={6}
-          pos={'relative'}>
+        <Box bg={'gray.100'} mt={-6} mx={-6} mb={6} pos={'relative'}>
           <Image
             src={
               'https://images.unsplash.com/photo-1515378791036-0648a3ef77b2?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1350&q=80'
             }
-            layout={'fill'}
           />
         </Box>
         <Stack>


### PR DESCRIPTION
**Issue**
I am using Chakra Templates a lot recently and I noticed that this component had a `next/image` import instead of a using the Chakra Image. Upon further investigation I realised that Chakra Templates is built with Next.js, however, the people that use Chakra UI and can find these templates useful, may not use Next.js.
I opened this PR since just changing the import did not solve my problem, I further had to change some CSS, so I believe this might help people in the future to not bother changing anything and just copy and paste the code as you mention on your homepage.

**Solution**
I removed the `<Image />` import from `next/image` and instead I used Chakra UI's `<Image />` component. I removed the box's fixed height so the image can shrink when we decrease the screen. Furthermore i added a `fit` prop with value 'contain' to the image to achieve responsiveness.

**Video**
https://www.veed.io/view/cd40c604-3d8d-4b7b-8e10-f5dc4a15295c?sharingWidget=true&panel=