### PR TITLE
[Fix]  #303  Dark mode make copy button invisible

### DIFF
--- a/src/components/CodeSample/CodeSample.tsx
+++ b/src/components/CodeSample/CodeSample.tsx
@@ -62,6 +62,7 @@ export const CodeSample = (props: Props) => {
         text={code}
         language={'tsx'}
         startingLineNumber={0}
+        theme={a11yDark}
         wrapLongLines
         showLineNumbers={false}
       />


### PR DESCRIPTION
Fix

Copy button get invisible on using dark mode.It makes harder to copy code.On light mode it works fine.

a11yDark was imported in code but never used , upon implementing theme property to CodeBlock and using a11yDark theme .Problem get solved.And copy button is visible for dark and light mode.

Other solution is to implement colorScheme='teal' property to Button to solve this issue.

But using  a11yDark is best as it was imported.Guess developer forgot to implement it. 